### PR TITLE
add option to use a random target for `trackfolder_var` dataset

### DIFF
--- a/data.py
+++ b/data.py
@@ -159,7 +159,7 @@ def load_datasets(parser, args):
         parser.add_argument(
             '--random-target-mix',
             action='store_true', default=False,
-            help='Apply random track mixing augmentation'
+            help='Apply random target mixing augmentation'
         )
         parser.add_argument(
             '--silence-missing', action='store_true', default=False,

--- a/data.py
+++ b/data.py
@@ -557,9 +557,7 @@ class VariableSourcesTrackFolderDataset(torch.utils.data.Dataset):
         Since the number of sources differ per track,
         while target is fixed, a random track mix
         augmentation cannot be used. Instead, a random track
-        can be used to load the target. If that is not available,
-        and `silence_missing_targets=True`, zeros will be used as
-        target
+        can be used to load the interfering sources.
 
         Also make sure, that you do not provide the mixture
         file among the sources!

--- a/docs/training.md
+++ b/docs/training.md
@@ -215,6 +215,7 @@ train/1/vocals.wav -----------------------> output
 |----------|-------------|---------|
 |`--target-file <str>` | file name of target file | `None` |
 |`--silence-missing-targets` | if a target is not among the list of sources it will be filled with zero | not set |
+|`random track mixing` | use _random track_ for target file to increase generalization of the model. | not set |
 |`--ext <str>` | File extension that is used to find the interfering files | `.wav` |
 |`--source-augmentations list[<str>]` | List of augmentation functions that are processed in the order of the list | `['gain', 'channelswap']` |
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -215,7 +215,7 @@ train/1/vocals.wav -----------------------> output
 |----------|-------------|---------|
 |`--target-file <str>` | file name of target file | `None` |
 |`--silence-missing-targets` | if a target is not among the list of sources it will be filled with zero | not set |
-|`random track mixing` | use _random track_ for target file to increase generalization of the model. | not set |
+|`random interferer mixing` | use _random track_ for the inference track to increase generalization of the model. | not set |
 |`--ext <str>` | File extension that is used to find the interfering files | `.wav` |
 |`--source-augmentations list[<str>]` | List of augmentation functions that are processed in the order of the list | `['gain', 'channelswap']` |
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This will add an option to apply an augmentation that selects a random track for just the interferer for the `trackfolder_var` dataset. This is similar to `random_interferer_mix` for the other datasets. However random track mixing for all sources is difficult to achieve for the the variable sources dataset since we cannot assume that the sources have the same names for each track.

#### Any other comments?

This also fixes a bug in the the `trackfolder_fix` dataset where the minimum duration was not calculated per track when `random-track-mix` was enabled
