### PR TITLE
fix typeerror

### DIFF
--- a/test.py
+++ b/test.py
@@ -289,9 +289,9 @@ def test_main(
 
         for target, estimate in estimates.items():
             sf.write(
-                outdir / Path(
+                str(outdir / Path(
                     Path(input_file).stem + '_' + target
-                ).with_suffix('.wav'),
+                ).with_suffix('.wav')),
                 estimate,
                 samplerate
             )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/sigsep/open-unmix-pytorch/blob/master/CONTRIBUTING.md 
->

#### Reference Issue
<!-- Example: Fixes #123 -->
Fix error TypeError: Invalid file: PosixPath('○○_umxhq/○○_drums.wav')

#### What does this implement/fix? Explain your changes.
plus `str` 290~297lines on test.py .

#### Any other comments?
Python3.5 User has this error!
There're no error on Python3.6.