### PR TITLE
Update ptorch 1.5 torchaudio 0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-runtime
+FROM pytorch/pytorch:1.5-cuda10.1-cudnn7-runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsox-fmt-all \
@@ -6,9 +6,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsox-dev
 
 WORKDIR /workspace
-
-# install torchaudio from source
-RUN git clone https://github.com/pytorch/audio.git pytorchaudio && cd pytorchaudio && python setup.py install
 
 COPY model.py /workspace
 COPY data.py /workspace
@@ -18,7 +15,7 @@ COPY eval.py /workspace
 COPY test.py /workspace
 COPY hubconf.py /workspace
 
-RUN conda install tqdm=4.28 ffmpeg resampy -c conda-forge
+RUN conda install tqdm ffmpeg resampy -c conda-forge
 
 RUN pip install musdb>=0.3.0
 RUN pip install norbert>=0.2.0

--- a/data.py
+++ b/data.py
@@ -1,4 +1,3 @@
-from utils import load_audio, load_info
 from pathlib import Path
 import torch.utils.data
 import argparse
@@ -7,6 +6,32 @@ import musdb
 import torch
 import tqdm
 import torchaudio
+
+
+def load_info(path):
+    # get length of file in samples
+    info = {}
+    si, _ = torchaudio.info(str(path))
+    info['samplerate'] = si.rate
+    info['samples'] = si.length // si.channels
+    info['duration'] = info['samples'] / si.rate
+    return info
+
+
+def load_audio(path, start=0, dur=None):
+    # loads the full track duration
+    if dur is None:
+        sig, rate = torchaudio.load(path)
+        return sig
+        # otherwise loads a random excerpt
+    else:
+        info = load_info(path)
+        num_frames = int(dur * info['samplerate'])
+        offset = int(start * info['samplerate'])
+        sig, rate = torchaudio.load(
+            path, num_frames=num_frames, offset=offset
+        )
+        return sig
 
 
 class Compose(object):

--- a/data.py
+++ b/data.py
@@ -6,6 +6,7 @@ import random
 import musdb
 import torch
 import tqdm
+import torchaudio
 
 
 class Compose(object):
@@ -857,17 +858,8 @@ if __name__ == "__main__":
         x, y = train_dataset[k]
         total_training_duration += x.shape[1] / train_dataset.sample_rate
         if args.save:
-            import soundfile as sf
-            sf.write(
-                "test/" + str(k) + 'x.wav',
-                x.detach().numpy().T,
-                44100,
-            )
-            sf.write(
-                "test/" + str(k) + 'y.wav',
-                y.detach().numpy().T,
-                44100,
-            )
+            torchaudio.save("test/" + str(k) + 'x.wav', x.T, 44100)
+            torchaudio.save("test/" + str(k) + 'y.wav', y.T, 44100)
 
     print("Total training duration (h): ", total_training_duration / 3600)
     print("Number of train samples: ", len(train_dataset))

--- a/data.py
+++ b/data.py
@@ -865,6 +865,9 @@ if __name__ == "__main__":
     )
 
     parser.add_argument('--target', type=str, default='vocals')
+    parser.add_argument('--seed', type=int, default=42)
+    parser.add_argument('--audio-backend', type=str, default="soundfile",
+                        help='Set torchaudio backend (`sox` or `soundfile`')
 
     # I/O Parameters
     parser.add_argument(
@@ -875,8 +878,10 @@ if __name__ == "__main__":
     parser.add_argument('--batch-size', type=int, default=16)
 
     args, _ = parser.parse_known_args()
-    train_dataset, valid_dataset, args = load_datasets(parser, args)
+    torchaudio.set_audio_backend(args.audio_backend)
 
+    train_dataset, valid_dataset, args = load_datasets(parser, args)
+    print("Audio Backend: ", torchaudio.get_audio_backend())
     # Iterate over training dataset
     total_training_duration = 0
     for k in tqdm.tqdm(range(len(train_dataset))):

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,6 +1,5 @@
 # Performing separation
 
-
 ## Interfacing using the command line
 
 The primary interface to separate files is the command line. To separate a mixture file into the four stems you can just run
@@ -9,8 +8,9 @@ The primary interface to separate files is the command line. To separate a mixtu
 python test.py input_file.wav
 ```
 
-Note that we support all files that can be read by pysoundfile (wav, flac and ogg files).
-The separation can be controlled with additional parameters that influence the performance of the separation. 
+Note that we support all files that can be read by torchaudio, depending on the set backend (either `soundfile` (libsndfile) or `sox`).
+For training, we set the default to `soundfile` as it is faster than `sox`. However for inference users might prefer `mp3` decoding capabilities.
+The separation can be controlled with additional parameters that influence the performance of the separation.
 
 | Command line Argument      | Description                                                                     | Default         |
 |----------------------------|---------------------------------------------------------------------------------|-----------------|
@@ -21,7 +21,8 @@ The separation can be controlled with additional parameters that influence the p
 | `--niter <int>`           | Number of EM steps for refining initial estimates in a post-processing stage. `--niter 0` skips this step altogether (and thus makes separation significantly faster) More iterations can get better interference reduction at the price of more artifacts.                                                  | `1`          |
 | `--residual`           |               computes a residual target, for custom separation scenarios when not all targets are available (at the expense of slightly less performance). E.g vocal/accompaniment can be performed with `--targets vocals --residual`.                                   | not set          |
 | `--softmask`       | if activated, then the initial estimates for the sources will be obtained through a ratio mask of the mixture STFT, and not by using the default behavior of reconstructing waveforms by using the mixture phase.  | not set            |
-| `--alpha <float>`         |In case of softmasking, this value changes the exponent to use for building ratio masks. A smaller value usually leads to more interference but better perceptual quality, whereas a larger value leads to less interference but an "overprocessed" sensation.                                                          | `1.0`            |
+| `--alpha <float>`         |In case of softmasking, this value changes the exponent to use for building ratio masks. A smaller value usually leads to more interference but better perceptual quality, whereas a larger value leads to less interference but an "overprocessed" sensation.                                                          | `1.0`                   |
+| `--audio-backend <str>`         | choose audio loading backend, either `sox` or `soundfile` | `soundfile` for training, `sox` for inference |
 
 ## Interfacing from python
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -61,6 +61,7 @@ An extensive list of additional training parameters allows researchers to quickl
 | `--nb-workers <int>`      | Number of (parallel) workers for data-loader, can be safely increased for wav files   | `0` |
 | `--quiet`                  | disable print and progress bar during training                                   | not set         |
 | `--seed <int>`             | Initial seed to set the random initialization                                   | `42`            |
+| `--audio-backend <str>`         | choose audio loading backend, either `sox` or `soundfile` | `soundfile` for training, `sox` for inference |
 
 ### Training details of `umxhq`
 

--- a/environment-cpu-linux.yml
+++ b/environment-cpu-linux.yml
@@ -1,4 +1,4 @@
-name: open-unmix-pytorch-dev-linux-cpu
+name: open-unmix-pytorch-linux-cpu
 
 channels:
   - conda-forge

--- a/environment-cpu-linux.yml
+++ b/environment-cpu-linux.yml
@@ -6,12 +6,13 @@ channels:
 
 dependencies:
   - python=3.7
-  - numpy=1.16
-  - scipy=1.3
-  - pytorch=1.3.1
+  - numpy=1.18
+  - scipy=1.4
+  - pytorch=1.5.0
   - cpuonly
-  - tqdm=4.32
-  - scikit-learn=0.21
+  - torchaudio=0.5.0
+  - tqdm
+  - scikit-learn=0.22
   - ffmpeg
   - resampy
   - pip

--- a/environment-cpu-osx.yml
+++ b/environment-cpu-osx.yml
@@ -1,4 +1,4 @@
-name: open-unmix-pytorch-dev-osx
+name: open-unmix-pytorch-osx
 
 channels:
   - conda-forge

--- a/environment-cpu-osx.yml
+++ b/environment-cpu-osx.yml
@@ -5,14 +5,14 @@ channels:
   - pytorch
 
 dependencies:
-  - python=3.7.3
-  - numpy=1.16
-  - scipy=1.3
-  - pytorch=1.3.1
-  - tqdm=4.32
-  - scikit-learn=0.21
+  - python=3.7
+  - numpy=1.18
+  - scipy=1.4
+  - pytorch=1.5.0
+  - torchaudio=0.5.0
+  - tqdm
+  - scikit-learn=0.22
   - ffmpeg
-  - resampy
   - pip
   - pip:
     - musdb==0.3.1

--- a/environment-gpu-linux-cuda10.yml
+++ b/environment-gpu-linux-cuda10.yml
@@ -6,12 +6,13 @@ channels:
 
 dependencies:
   - python=3.7
-  - numpy=1.16
-  - scipy=1.3
-  - pytorch=1.3.1
+  - numpy=1.18
+  - scipy=1.4
+  - pytorch=1.5.0
+  - torchaudio=0.5.0
   - cudatoolkit=10.0
-  - scikit-learn=0.21
-  - tqdm=4.32
+  - scikit-learn=0.22
+  - tqdm
   - ffmpeg
   - resampy
   - pip

--- a/environment-gpu-linux-cuda10.yml
+++ b/environment-gpu-linux-cuda10.yml
@@ -1,4 +1,4 @@
-name: open-unmix-pytorch-dev-gpu
+name: open-unmix-pytorch-gpu
 
 channels:
   - conda-forge

--- a/test.py
+++ b/test.py
@@ -93,7 +93,7 @@ def separate(
 
     Parameters
     ----------
-    audio: torch tenso [shape=(nb_samples, nb_channels, nb_timesteps)]
+    audio: torch tensor [shape=(nb_samples, nb_channels, nb_timesteps)]
         mixture audio
 
     targets: list of str
@@ -251,7 +251,7 @@ def test_main(
             warnings.warn(
                 'Channel count > 2! '
                 'Only the first two channels will be processed!')
-            audio = audio[:2, :]
+            audio = audio[:2]
 
         if info['samplerate'] != samplerate:
             # resample to model samplerate if needed

--- a/test.py
+++ b/test.py
@@ -1,12 +1,12 @@
 import torch
 import numpy as np
 import argparse
-import soundfile as sf
+import data
 import norbert
 import json
 from pathlib import Path
 import scipy.signal
-import resampy
+import torchaudio
 import model
 import utils
 import warnings
@@ -93,7 +93,7 @@ def separate(
 
     Parameters
     ----------
-    audio: np.ndarray [shape=(nb_samples, nb_channels, nb_timesteps)]
+    audio: torch tenso [shape=(nb_samples, nb_channels, nb_timesteps)]
         mixture audio
 
     targets: list of str
@@ -131,7 +131,7 @@ def separate(
 
     """
     # convert numpy audio to torch
-    audio_torch = torch.tensor(audio.T[None, ...]).float().to(device)
+    audio_torch = torch.as_tensor(audio.T[None, ...]).float().to(device)
 
     source_names = []
     V = []
@@ -234,40 +234,41 @@ def test_main(
 
     for input_file in input_files:
         # handling an input audio path
-        info = sf.info(input_file)
-        start = int(start * info.samplerate)
+        info = data.load_info(input_file)
         # check if dur is none
-        if duration > 0:
-            # stop in soundfile is calc in samples, not seconds
-            stop = start + int(duration * info.samplerate)
-        else:
+        if info['duration'] <= 0:
             # set to None for reading complete file
-            stop = None
+            duration = None
+        else:
+            duration = info['duration']
 
-        audio, rate = sf.read(
+        audio = data.load_audio(
             input_file,
-            always_2d=True,
             start=start,
-            stop=stop
+            dur=duration
         )
-
-        if audio.shape[1] > 2:
+        if audio.shape[0] > 2:
             warnings.warn(
                 'Channel count > 2! '
                 'Only the first two channels will be processed!')
-            audio = audio[:, :2]
+            audio = audio[:2, :]
 
-        if rate != samplerate:
+        if info['samplerate'] != samplerate:
             # resample to model samplerate if needed
-            audio = resampy.resample(audio, rate, samplerate, axis=0)
+            resampler = torchaudio.transforms.Resample(
+                info['samplerate'],
+                samplerate,
+                resampling_method='sinc_interpolation'
+            )
+            audio = resampler(audio)
 
         if audio.shape[1] == 1:
             # if we have mono, let's duplicate it
             # as the input of OpenUnmix is always stereo
-            audio = np.repeat(audio, 2, axis=1)
+            audio = torch.repeat_interleave(audio, 2, dim=1)
 
         estimates = separate(
-            audio,
+            audio.T,
             targets=targets,
             model_name=model,
             niter=niter,
@@ -293,9 +294,9 @@ def test_main(
         output_path.mkdir(exist_ok=True, parents=True)
 
         for target, estimate in estimates.items():
-            sf.write(
+            torchaudio.save(
                 str(output_path / Path(target).with_suffix('.wav')),
-                estimate,
+                torch.tensor(estimate.T),
                 samplerate
             )
 
@@ -357,8 +358,17 @@ if __name__ == '__main__':
         help='disables CUDA inference'
     )
 
+    parser.add_argument(
+        '--audio-backend',
+        type=str,
+        default="sox",
+        help='Set torchaudio backend '
+             '(`sox` or `soundfile`), defaults to `sox`')
+
     args, _ = parser.parse_known_args()
     args = inference_args(parser, args)
+
+    torchaudio.set_audio_backend(args.audio_backend)
 
     test_main(
         input_files=args.input, samplerate=args.samplerate,

--- a/train.py
+++ b/train.py
@@ -13,7 +13,7 @@ import random
 from git import Repo
 import os
 import copy
-
+import torchaudio
 
 tqdm.monitor_interval = 0
 
@@ -96,8 +96,10 @@ def main():
     parser.add_argument('--output', type=str, default="open-unmix",
                         help='provide output path base folder name')
     parser.add_argument('--model', type=str, help='Path to checkpoint folder')
+    parser.add_argument('--audio-backend', type=str, default="soundfile",
+                        help='Set torchaudio backend (`sox` or `soundfile`')
 
-    # Trainig Parameters
+    # Training Parameters
     parser.add_argument('--epochs', type=int, default=1000)
     parser.add_argument('--batch-size', type=int, default=16)
     parser.add_argument('--lr', type=float, default=0.001,
@@ -140,6 +142,7 @@ def main():
 
     args, _ = parser.parse_known_args()
 
+    torchaudio.set_audio_backend(args.audio_backend)
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     print("Using GPU:", use_cuda)
     dataloader_kwargs = {'num_workers': args.nb_workers, 'pin_memory': True} if use_cuda else {}

--- a/train.py
+++ b/train.py
@@ -142,7 +142,6 @@ def main():
 
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     print("Using GPU:", use_cuda)
-    print("Using Torchaudio: ", utils._torchaudio_available())
     dataloader_kwargs = {'num_workers': args.nb_workers, 'pin_memory': True} if use_cuda else {}
 
     repo_dir = os.path.abspath(os.path.dirname(__file__))

--- a/utils.py
+++ b/utils.py
@@ -2,33 +2,6 @@ import shutil
 import torch
 import os
 import numpy as np
-import torchaudio
-
-
-def load_info(path):
-    # get length of file in samples
-    info = {}
-    si, _ = torchaudio.info(str(path))
-    info['samplerate'] = si.rate
-    info['samples'] = si.length // si.channels
-    info['duration'] = info['samples'] / si.rate
-    return info
-
-
-def load_audio(path, start=0, dur=None):
-    # loads the full track duration
-    if dur is None:
-        sig, rate = torchaudio.load(path)
-        return sig
-        # otherwise loads a random excerpt
-    else:
-        info = load_info(path)
-        num_frames = int(dur * info['samplerate'])
-        offset = int(start * info['samplerate'])
-        sig, rate = torchaudio.load(
-            path, num_frames=num_frames, offset=offset
-        )
-        return sig
 
 
 def bandwidth_to_max_bin(rate, n_fft, bandwidth):

--- a/utils.py
+++ b/utils.py
@@ -2,76 +2,10 @@ import shutil
 import torch
 import os
 import numpy as np
+import torchaudio
 
 
-def _sndfile_available():
-    try:
-        import soundfile
-    except ImportError:
-        return False
-
-    return True
-
-
-def _torchaudio_available():
-    try:
-        import torchaudio
-    except ImportError:
-        return False
-
-    return True
-
-
-def get_loading_backend():
-    if _torchaudio_available():
-        return torchaudio_loader
-
-    if _sndfile_available():
-        return soundfile_loader
-
-
-def get_info_backend():
-    if _torchaudio_available():
-        return torchaudio_info
-
-    if _sndfile_available():
-        return soundfile_info
-
-
-def soundfile_info(path):
-    import soundfile
-    info = {}
-    sfi = soundfile.info(path)
-    info['samplerate'] = sfi.samplerate
-    info['samples'] = int(sfi.duration * sfi.samplerate)
-    info['duration'] = sfi.duration
-    return info
-
-
-def soundfile_loader(path, start=0, dur=None):
-    import soundfile
-    # get metadata
-    info = soundfile_info(path)
-    start = int(start * info['samplerate'])
-    # check if dur is none
-    if dur:
-        # stop in soundfile is calc in samples, not seconds
-        stop = start + int(dur * info['samplerate'])
-    else:
-        # set to None for reading complete file
-        stop = dur
-
-    audio, _ = soundfile.read(
-        path,
-        always_2d=True,
-        start=start,
-        stop=stop
-    )
-    return torch.FloatTensor(audio.T)
-
-
-def torchaudio_info(path):
-    import torchaudio
+def load_info(path):
     # get length of file in samples
     info = {}
     si, _ = torchaudio.info(str(path))
@@ -81,31 +15,20 @@ def torchaudio_info(path):
     return info
 
 
-def torchaudio_loader(path, start=0, dur=None):
-    import torchaudio
-    info = torchaudio_info(path)
+def load_audio(path, start=0, dur=None):
     # loads the full track duration
     if dur is None:
         sig, rate = torchaudio.load(path)
         return sig
         # otherwise loads a random excerpt
     else:
+        info = load_info(path)
         num_frames = int(dur * info['samplerate'])
         offset = int(start * info['samplerate'])
         sig, rate = torchaudio.load(
             path, num_frames=num_frames, offset=offset
         )
         return sig
-
-
-def load_info(path):
-    loader = get_info_backend()
-    return loader(path)
-
-
-def load_audio(path, start=0, dur=None):
-    loader = get_loading_backend()
-    return loader(path, start=start, dur=dur)
 
 
 def bandwidth_to_max_bin(rate, n_fft, bandwidth):


### PR DESCRIPTION
This PR implements

* update environment to pytorch 1.5 and torchaudio 0.5
* remove soundfile dataloader as it is now an optional backend of torchaudio 
* set backend to `soundfile` for training and `sox` for inference
* remove all audio loading code that uses pysoundfile
* replace resampy with native torchaudio resampling