### PR TITLE
removing torch.atan2 from wiener function. Magnitude computation to d…

### DIFF
--- a/openunmix/filtering.py
+++ b/openunmix/filtering.py
@@ -6,23 +6,30 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.utils.data import DataLoader
-import math
 
 
+def atan2(y, x):
+    r"""Element-wise arctangent function of y/x.
+    Returns a new tensor with signed angles in radians.
+    It is an alternative implementation of torch.atan2
 
+    Args:
+        y (Tensor): First input tensor
+        x (Tensor): Second input tensor [shape=y.shape]
 
-
-def my_atan2(y, x):
-    pi = math.pi
+    Returns:
+        Tensor: [shape=y.shape].
+    """
+    pi = 2*torch.asin(torch.tensor(1.))
     x +=  ((x==0) & (y==0)) *  1.0 
-    ans = torch.atan(y / x)
-    ans += ((y >= 0) & (x < 0)) * pi
-    ans -= ((y < 0) & (x < 0)) * pi
-    ans *= (1 - ((y > 0) & (x == 0)) * 1.0)
-    ans += ((y > 0) & (x == 0)) * (pi / 2)
-    ans *= (1 - ((y < 0) & (x == 0)) * 1.0)
-    ans += ((y < 0) & (x == 0)) * (-pi / 2)
-    return ans
+    out = torch.atan(y / x)
+    out += ((y >= 0) & (x < 0)) * pi
+    out -= ((y < 0) & (x < 0)) * pi
+    out *= (1 - ((y > 0) & (x == 0)) * 1.0)
+    out += ((y > 0) & (x == 0)) * (pi / 2)
+    out *= (1 - ((y < 0) & (x == 0)) * 1.0)
+    out += ((y < 0) & (x == 0)) * (-pi / 2)
+    return out
 
 
 
@@ -490,17 +497,7 @@ def wiener(
     else:
         # otherwise, we just multiply the targets spectrograms with mix phase
         # we tacitly assume that we have magnitude estimates.
-        """
-        angle = torch.atan2(mix_stft[..., 1], mix_stft[..., 0])[..., None]
-        nb_sources = targets_spectrograms.shape[-1]
-        y = torch.zeros(mix_stft.shape + (nb_sources,), dtype=mix_stft.dtype,
-                        device=mix_stft.device)
-        y[..., 0, :] = targets_spectrograms * torch.cos(angle)
-        y[..., 1, :] = targets_spectrograms * torch.sin(angle)
-        """
-        
-        # Version with home made atan2 
-        angle = my_atan2(mix_stft[..., 1], mix_stft[..., 0])[..., None]
+        angle = atan2(mix_stft[..., 1], mix_stft[..., 0])[..., None]
         nb_sources = targets_spectrograms.shape[-1]
         y = torch.zeros(mix_stft.shape + (nb_sources,), dtype=mix_stft.dtype,
                         device=mix_stft.device)

--- a/openunmix/filtering.py
+++ b/openunmix/filtering.py
@@ -6,14 +6,14 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.utils.data import DataLoader
-import numpy as np
+import math
 
 
 
 
 
 def my_atan2(y, x):
-    pi = torch.from_numpy(np.array([np.pi])).to(y.device, y.dtype)
+    pi = math.pi
     x +=  ((x==0) & (y==0)) *  1.0 
     ans = torch.atan(y / x)
     ans += ((y >= 0) & (x < 0)) * pi

--- a/openunmix/filtering.py
+++ b/openunmix/filtering.py
@@ -9,16 +9,22 @@ from torch.utils.data import DataLoader
 import numpy as np
 
 
+
+
+
 def my_atan2(y, x):
     pi = torch.from_numpy(np.array([np.pi])).to(y.device, y.dtype)
+    x +=  ((x==0) & (y==0)) *  1.0 
     ans = torch.atan(y / x)
-    ans += ((y > 0) & (x < 0)) * pi
+    ans += ((y >= 0) & (x < 0)) * pi
     ans -= ((y < 0) & (x < 0)) * pi
     ans *= (1 - ((y > 0) & (x == 0)) * 1.0)
     ans += ((y > 0) & (x == 0)) * (pi / 2)
     ans *= (1 - ((y < 0) & (x == 0)) * 1.0)
     ans += ((y < 0) & (x == 0)) * (-pi / 2)
     return ans
+
+
 
 # Define basic complex operations on torch.Tensor objects whose last dimension
 # consists in the concatenation of the real and imaginary parts.
@@ -492,6 +498,7 @@ def wiener(
         y[..., 0, :] = targets_spectrograms * torch.cos(angle)
         y[..., 1, :] = targets_spectrograms * torch.sin(angle)
         """
+        
         # Version with home made atan2 
         angle = my_atan2(mix_stft[..., 1], mix_stft[..., 0])[..., None]
         nb_sources = targets_spectrograms.shape[-1]

--- a/openunmix/filtering.py
+++ b/openunmix/filtering.py
@@ -471,12 +471,24 @@ def wiener(
     else:
         # otherwise, we just multiply the targets spectrograms with mix phase
         # we tacitly assume that we have magnitude estimates.
+        """
         angle = torch.atan2(mix_stft[..., 1], mix_stft[..., 0])[..., None]
         nb_sources = targets_spectrograms.shape[-1]
         y = torch.zeros(mix_stft.shape + (nb_sources,), dtype=mix_stft.dtype,
                         device=mix_stft.device)
         y[..., 0, :] = targets_spectrograms * torch.cos(angle)
         y[..., 1, :] = targets_spectrograms * torch.sin(angle)
+        """
+        # Version without using atan2 (computing mag instead)
+        mag = (mix_stft[..., 0]**2 + mix_stft[..., 1]**2)**(0.5)
+        cosangle = mix_stft[..., 0] / mag
+        sinangle = mix_stft[..., 1] / mag
+        nb_sources = targets_spectrograms.shape[-1]
+        y = torch.zeros(mix_stft.shape + (nb_sources,), dtype=mix_stft.dtype,
+                        device=mix_stft.device)
+        y[..., 0, :] = targets_spectrograms * cosangle[...,None]
+        y[..., 1, :] = targets_spectrograms * sinangle[...,None]
+
 
     if residual:
         # if required, adding an additional target as the mix minus

--- a/openunmix/filtering.py
+++ b/openunmix/filtering.py
@@ -6,6 +6,19 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.utils.data import DataLoader
+import numpy as np
+
+
+def my_atan2(y, x):
+    pi = torch.from_numpy(np.array([np.pi])).to(y.device, y.dtype)
+    ans = torch.atan(y / x)
+    ans += ((y > 0) & (x < 0)) * pi
+    ans -= ((y < 0) & (x < 0)) * pi
+    ans *= (1 - ((y > 0) & (x == 0)) * 1.0)
+    ans += ((y > 0) & (x == 0)) * (pi / 2)
+    ans *= (1 - ((y < 0) & (x == 0)) * 1.0)
+    ans += ((y < 0) & (x == 0)) * (-pi / 2)
+    return ans
 
 # Define basic complex operations on torch.Tensor objects whose last dimension
 # consists in the concatenation of the real and imaginary parts.
@@ -479,15 +492,13 @@ def wiener(
         y[..., 0, :] = targets_spectrograms * torch.cos(angle)
         y[..., 1, :] = targets_spectrograms * torch.sin(angle)
         """
-        # Version without using atan2 (computing mag instead)
-        mag = (mix_stft[..., 0]**2 + mix_stft[..., 1]**2)**(0.5)
-        cosangle = mix_stft[..., 0] / mag
-        sinangle = mix_stft[..., 1] / mag
+        # Version with home made atan2 
+        angle = my_atan2(mix_stft[..., 1], mix_stft[..., 0])[..., None]
         nb_sources = targets_spectrograms.shape[-1]
         y = torch.zeros(mix_stft.shape + (nb_sources,), dtype=mix_stft.dtype,
                         device=mix_stft.device)
-        y[..., 0, :] = targets_spectrograms * cosangle[...,None]
-        y[..., 1, :] = targets_spectrograms * sinangle[...,None]
+        y[..., 0, :] = targets_spectrograms * torch.cos(angle)
+        y[..., 1, :] = targets_spectrograms * torch.sin(angle)
 
 
     if residual:


### PR DESCRIPTION
…etermine cos and sin

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/sigsep/open-unmix-pytorch/blob/master/CONTRIBUTING.md 
->

#### Reference Issue
<!-- Example: Fixes #123 -->

#### What does this implement/fix? Explain your changes.

This removes the atan2 from wiener function and replace by another computation. This is a try made to export model in other format.

#### Any other comments?
