### PR TITLE
The default option for --is-wav is False

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -42,7 +42,7 @@ Some of the parameters for the MUSDB sampling can be controlled using the follow
 
 | Argument      | Description                                                            | Default      |
 |---------------------|-----------------------------------------------|--------------|
-| `--is-wav`          | loads the decoded WAVs instead of STEMS for faster data loading. See [more details here](https://github.com/sigsep/sigsep-mus-db#using-wav-files-optional). | `True`      |
+| `--is-wav`          | loads the decoded WAVs instead of STEMS for faster data loading. See [more details here](https://github.com/sigsep/sigsep-mus-db#using-wav-files-optional). | `False`      |
 | `--samples-per-track <int>` | sets the number of samples that are randomly drawn from each track  | `64`       |
 | `--source-augmentations <list[str]>` | applies augmentations to each audio source before mixing, available augmentations: `[gain, channelswap]`| [gain, channelswap]       |
 


### PR DESCRIPTION
I was trying to use the MusDB-HQ dataset which contains WAV files. When I did not explicitly mention the --is-wav argument, it was throwing an error. It was working only for the dataset with STEM files. So I guess the default should be false in the documentation. Kindly confirm.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/sigsep/open-unmix-pytorch/blob/master/CONTRIBUTING.md 
->

#### Reference Issue
<!-- Example: Fixes #123 -->

#### What does this implement/fix? Explain your changes.


#### Any other comments?
