### PR TITLE
Set unidirectional flag

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -268,6 +268,7 @@ def main():
             nb_channels=args.nb_channels,
             hidden_size=args.hidden_size,
             max_bin=max_bin,
+            unidirectional=args.unidirectional
         ).to(device)
 
     optimizer = torch.optim.Adam(unmix.parameters(), lr=args.lr, weight_decay=args.weight_decay)


### PR DESCRIPTION
The unidirectional flag is present in the args (which is False by default), but not set when creating the model.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/sigsep/open-unmix-pytorch/blob/master/CONTRIBUTING.md 
->

#### Reference Issue
<!-- Example: Fixes #123 -->

#### What does this implement/fix? Explain your changes.


#### Any other comments?
